### PR TITLE
docs: prefer in-container tooling for local Docker databases

### DIFF
--- a/harnesses/claude/CLAUDE.md
+++ b/harnesses/claude/CLAUDE.md
@@ -11,6 +11,10 @@
 
 - Prefer conventional commits unless otherwise specified.
 
+## Local Docker databases
+
+- When working with a database running in a local Docker container, prefer the tooling inside the container (via `docker [compose] exec`) to inspect or modify data. Only fall back to host tooling when the required tool is not available inside the container.
+
 ## Plans
 
 - At the end of each plan, give me a list of unresolved questions to answer, if any. Make the questions extremely concise. Sacrifice grammar for the sake of concision.


### PR DESCRIPTION
Adds a "Local Docker databases" section to the global CLAUDE.md.
It instructs agents to prefer tooling inside the container (via `docker [compose] exec`) when inspecting or modifying data in a local Docker database, falling back to host tooling only when the required tool isn't available in the container.